### PR TITLE
fix: 🐛 detect correct type using also zentype

### DIFF
--- a/src/applets.ts
+++ b/src/applets.ts
@@ -194,7 +194,7 @@ const proctoroom = `
 				schema: JSON.parse(schema),
 				compact: true,
 				disable_collapse: true,
-				disable_edit_json: true,
+				disable_edit_json: false,
 				disable_properties: true,
 				required_by_default: true,
 				show_errors: 'interaction',
@@ -255,9 +255,7 @@ const proctoroom = `
 				outline-width: 8px;
 				outline-style: solid;
 			}
-			.je-header {
-				display: none;
-			}
+			.je-header {}
 			.je-object__container {
 				border: none;
 			}

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,9 +30,9 @@ export interface Endpoints {
 }
 
 interface CodecAttr {
-	encoding: 'string' | 'number';
+	encoding: 'string' | 'float';
 	name: string;
-	zentype: 'n' | 'y';
+	zentype: 'd' | 'a' | 'e';
 }
 
 export interface Codec {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ export async function getSchemaFromIntrospection(
 		const codec: Codec = await introspect(contract);
 		const encodingToType = {
 			string: Type.String(),
-			number: Type.Number()
+			float: Type.Number()
 		};
 		const schema = Type.Object(
 			Object.fromEntries(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,7 +31,21 @@ export async function getSchemaFromIntrospection(
 		};
 		const schema = Type.Object(
 			Object.fromEntries(
-				Object.values(codec).map(({ name, encoding }) => [name, encodingToType[encoding]])
+				Object.values(codec).map(({ name, zentype, encoding }) => {
+					let t;
+					switch (zentype) {
+						case "d":
+							t = Type.Record(Type.String(), encodingToType[encoding]);
+							break;
+						case "a":
+							t = Type.Array(encodingToType[encoding]);
+							break;
+						default:
+							t = encodingToType[encoding];
+							break;
+					}
+				return [name, t];
+				})
 			)
 		);
 		return schema;


### PR DESCRIPTION
TODO: 
* hide `root` in the `/app` page 