### PR TITLE
chore: specify packageManager in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 	"engines": {
 		"node": ">=20.0.0 <22.0.0"
 	},
+	"packageManager": "pnpm@9.4.0",
 	"bin": {
 		"ncr": "dist/index.cjs"
 	},


### PR DESCRIPTION
In this way dependabot should use the correct pnpm version
