### PR TITLE
refactor: do not print an error on .autorun folder not found

### DIFF
--- a/src/autorun.ts
+++ b/src/autorun.ts
@@ -51,7 +51,6 @@ async function getContractPathsInDirectory(directoryPath: string): Promise<strin
 			.filter((name) => isZencodeFile(name))
 			.map((name) => join(directoryPath, name));
 	} catch (e) {
-		L.error(e);
 		return [];
 	}
 }
@@ -67,8 +66,7 @@ async function runContractData({ contract, keys, conf, data, path }: ContractDat
 	try {
 		const s = SlangroomManager.getInstance();
 		const { result } = await s.execute(contract, { keys, data, conf });
-		L.info('Run contract');
-		L.info(path);
+		L.info(`Running autorun contract ${path}`);
 		L.info(result);
 	} catch (e) {
 		L.error(e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,9 @@ const ncrApp = async () => {
 			res.writeStatus('200 OK').writeHeader('Content-Type', 'text/html').end(openapiTemplate);
 		})
 		.get('/oas.json', async (res, req) => {
+			definition.paths = {};
 			await Promise.all(
 				Dir.files.map(async (endpoints) => {
-					definition.paths = {};
 					const { path, metadata } = endpoints;
 					if (definition.paths && !metadata.hidden && !metadata.hideFromOpenapi) {
 						const schema = await getSchema(endpoints);


### PR DESCRIPTION
Specify better that the initial contracts that are executed are those present in the autorun folder
