### PR TITLE
fix: create or reload API on addition, modification or deletion of related files in zencodeDir

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,7 +56,7 @@ program
 	.addOption(
 		new Option(
 			'-p, --port <number>',
-			'specify port number; if unspecified restroom will listen to a random free port'
+			'specify port number; if unspecified ncr will listen to a random free port'
 		)
 			.env('PORT')
 			.default(0)

--- a/src/directory.ts
+++ b/src/directory.ts
@@ -105,5 +105,7 @@ export class Directory {
 
 	public onChange(cb: (...args: any[]) => void) {
 		this.liveDirectory.on('add', cb);
+		this.liveDirectory.on('update', cb);
+		this.liveDirectory.on('delete', cb);
 	}
 }

--- a/src/directory.ts
+++ b/src/directory.ts
@@ -103,9 +103,19 @@ export class Directory {
 		this.liveDirectory.once('ready', cb);
 	}
 
-	public onChange(cb: (...args: any[]) => void) {
-		this.liveDirectory.on('add', cb);
-		this.liveDirectory.on('update', cb);
-		this.liveDirectory.on('delete', cb);
+	private onChange(event: string, cb: (...args: any[]) => void) {
+		this.liveDirectory.on(event, cb);
+	}
+
+	public onAdd(cb: (path: string, file: LiveFile) => void) {
+		this.onChange('add', cb);
+	}
+
+	public onUpdate(cb: (path: string, file: LiveFile) => void) {
+		this.onChange('update', cb);
+	}
+
+	public onDelete(cb: (path: string) => void) {
+		this.onChange('delete', cb);
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,15 +162,7 @@ const runPrecondition = async (preconditionPath: string, data: Record<string, an
 	await s.execute(zen, {data, keys});
 };
 
-Dir.ready(async () => {
-	let listen_socket: us_listen_socket;
-
-	const app = await ncrApp();
-
-	await autorunContracts();
-
-	generateRoutes(app);
-
+const generatePublicDirectory = (app: TemplatedApp) => {
 	const { publicDirectory } = config;
 	if (publicDirectory) {
 		app.get('/*', async (res, req) => {
@@ -210,6 +202,18 @@ Dir.ready(async () => {
 			}
 		});
 	}
+}
+
+Dir.ready(async () => {
+	let listen_socket: us_listen_socket;
+
+	const app = await ncrApp();
+
+	await autorunContracts();
+
+	generateRoutes(app);
+
+	generatePublicDirectory(app);
 
 	app.listen(config.port, LIBUS_LISTEN_EXCLUSIVE_PORT, (socket) => {
 		if (socket) {
@@ -228,7 +232,8 @@ Dir.ready(async () => {
 			us_listen_socket_close(listen_socket);
 			const app = await ncrApp();
 			generateRoutes(app);
-			app.listen(port, (socket) => {
+			generatePublicDirectory(app);
+			app.listen(port, LIBUS_LISTEN_EXCLUSIVE_PORT, (socket) => {
 				listen_socket = socket;
 				L.info(`Swagger UI is running on http://${config.hostname}:${port}/docs`);
 			});

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,19 +227,20 @@ Dir.ready(async () => {
 	});
 
 	Dir.onChange(async () => {
-		try {
-			const port = us_socket_local_port(listen_socket);
-			us_listen_socket_close(listen_socket);
-			const app = await ncrApp();
-			generateRoutes(app);
-			generatePublicDirectory(app);
-			app.listen(port, LIBUS_LISTEN_EXCLUSIVE_PORT, (socket) => {
+		const port = us_socket_local_port(listen_socket);
+		us_listen_socket_close(listen_socket);
+		const app = await ncrApp();
+		generateRoutes(app);
+		generatePublicDirectory(app);
+		app.listen(port, LIBUS_LISTEN_EXCLUSIVE_PORT, (socket) => {
+			if (socket) {
 				listen_socket = socket;
 				L.info(`Swagger UI is running on http://${config.hostname}:${port}/docs`);
-			});
-		} catch (error) {
-			L.error(error);
-		}
+			} else {
+				L.error(`Not able to reload the server`);
+				throw new Error('Not able to reload the server');
+			}
+		});
 	});
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,20 +227,7 @@ Dir.ready(async () => {
 	});
 
 	Dir.onChange(async () => {
-		const port = us_socket_local_port(listen_socket);
-		us_listen_socket_close(listen_socket);
-		const app = await ncrApp();
 		generateRoutes(app);
-		generatePublicDirectory(app);
-		app.listen(port, LIBUS_LISTEN_EXCLUSIVE_PORT, (socket) => {
-			if (socket) {
-				listen_socket = socket;
-				L.info(`Swagger UI is running on http://${config.hostname}:${port}/docs`);
-			} else {
-				L.error(`Not able to reload the server`);
-				throw new Error('Not able to reload the server');
-			}
-		});
 	});
 });
 

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -165,7 +165,7 @@ export const openapiTemplate = `
 		<div id="swagger-ui"></div>
 		<script src="https://unpkg.com/swagger-ui-dist@latest/swagger-ui-bundle.js" crossorigin></script>
 		<script>
-			window.onload = async () => {
+			window.onload = () => {
 				window.ui = SwaggerUIBundle({
 					url: '/oas.json',
 					dom_id: '#swagger-ui'

--- a/src/responseUtils.ts
+++ b/src/responseUtils.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2024 The Forkbomb Company
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { Logger, type ILogObj } from 'tslog';
+import { HttpResponse } from 'uWebSockets.js';
+
+export const forbidden = (res: HttpResponse, LOG: Logger<ILogObj>, e: Error) => {
+	if (res.aborted) return;
+	LOG.fatal(e.message);
+	res.cork(() => {
+		res
+			.writeStatus('403 FORBIDDEN')
+			.writeHeader('Content-Type', 'application/json')
+			.writeHeader('Access-Control-Allow-Origin', '*')
+			.end('Forbidden');
+	});
+};
+
+export const notFound = (res: HttpResponse, LOG: Logger<ILogObj>, e: Error) => {
+	if (res.aborted) return;
+	LOG.fatal(e.message);
+	res.cork(() => {
+		res
+			.writeStatus('404 NOT FOUND')
+			.writeHeader('Content-Type', 'application/json')
+			.writeHeader('Access-Control-Allow-Origin', '*')
+			.end('Not Found');
+	});
+};
+
+export const methodNotAllowed = (res: HttpResponse, LOG: Logger<ILogObj>, e: Error) => {
+	if (res.aborted) return;
+	LOG.warn(e.message);
+	res.cork(() => {
+		res
+			.writeStatus('405 METHOD NOT ALLOWED')
+			.writeHeader('Content-Type', 'application/json')
+			.writeHeader('Access-Control-Allow-Origin', '*')
+			.end('Method Not Allowed');
+	});
+};
+
+export const unprocessableEntity = (res: HttpResponse, LOG: Logger<ILogObj>, e: Error) => {
+	if (res.aborted) return;
+	LOG.fatal(e.message);
+	res.cork(() => {
+		res
+			.writeStatus('422 UNPROCESSABLE ENTITY')
+			.writeHeader('Content-Type', 'application/json')
+			.writeHeader('Access-Control-Allow-Origin', '*')
+			.end(e.message);
+	});
+};
+
+export const internalServerError = (res: HttpResponse, LOG: Logger<ILogObj>, e: Error) => {
+	if (res.aborted) return;
+	LOG.fatal(e.message);
+	res.cork(() => {
+		res
+			.writeStatus('500 INTERNAL SERVER ERROR')
+			.writeHeader('Content-Type', 'application/json')
+			.writeHeader('Access-Control-Allow-Origin', '*')
+			.end(e.message);
+	});
+};

--- a/src/routeUtils.ts
+++ b/src/routeUtils.ts
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: 2024 The Forkbomb Company
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import fs from 'fs';
+import _ from 'lodash';
+import { HttpResponse, TemplatedApp } from 'uWebSockets.js';
+import { execute as slangroomChainExecute } from '@dyne/slangroom-chain';
+
+import { reportZenroomError } from './error.js';
+import { Endpoints, JSONSchema, Logger, ILogObj } from './types.js';
+import { config } from './cli.js';
+import { SlangroomManager } from './slangroom.js';
+import { forbidden, methodNotAllowed, notFound, unprocessableEntity } from './responseUtils.js';
+import { getSchema, validateData, getQueryParams } from './utils.js';
+
+const L = config.logger;
+const emoji = {
+	add: '📜',
+	update: '📝',
+	delete: '🗑️ '
+};
+
+const setCorsHeaders = (res: HttpResponse) => {
+	res
+		.writeHeader('Access-Control-Allow-Origin', '*')
+		.writeHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+		.writeHeader('Access-Control-Allow-Headers', 'content-type, authorization');
+};
+
+export const runPrecondition = async (preconditionPath: string, data: Record<string, any>) => {
+	const s = SlangroomManager.getInstance();
+	const zen = fs.readFileSync(preconditionPath + '.slang').toString();
+	const keys = fs.existsSync(preconditionPath + '.keys.json')
+		? JSON.parse(fs.readFileSync(preconditionPath + '.keys.json'))
+		: null;
+	await s.execute(zen, { data, keys });
+};
+
+const execZencodeAndReply = async (
+	res: HttpResponse,
+	endpoint: Endpoints,
+	data: JSON | Record<string, unknown>,
+	headers: Record<string, Record<string, string>>,
+	schema: JSONSchema,
+	LOG: Logger<ILogObj>
+) => {
+	res.onAborted(() => {
+		res.aborted = true;
+		res.cork(() => res.writeStatus('400').end());
+		return;
+	});
+	const { contract, chain, path, keys, conf, metadata } = endpoint;
+	try {
+		if (metadata.httpHeaders) {
+			try {
+				if (data['http_headers'] !== undefined) {
+					throw new Error('Name clash on input key http_headers');
+				}
+				data['http_headers'] = headers;
+			} catch (e) {
+				unprocessableEntity(res, LOG, e as Error);
+				return;
+			}
+		}
+		if (metadata.precondition) {
+			try {
+				await runPrecondition(metadata.precondition, data);
+			} catch (e) {
+				forbidden(res, LOG, e as Error);
+				return;
+			}
+		}
+
+		try {
+			validateData(schema, data);
+		} catch (e) {
+			unprocessableEntity(res, LOG, e as Error);
+			return;
+		}
+
+		let jsonResult: Record<string, unknown>;
+		try {
+			if (chain) {
+				const dataFormatted = data ? JSON.stringify(data) : undefined;
+				const parsedChain = eval(chain)();
+				const res = await slangroomChainExecute(parsedChain, dataFormatted);
+				jsonResult = JSON.parse(res);
+			} else {
+				const s = SlangroomManager.getInstance();
+				({ result: jsonResult } = await s.execute(contract, { keys, data, conf }));
+			}
+		} catch (e) {
+			if (!res.aborted) {
+				res.cork(() => {
+					const report = reportZenroomError(e as Error, LOG, endpoint);
+					res
+						.writeStatus(metadata.errorCode)
+						.writeHeader('Access-Control-Allow-Origin', '*')
+						.end(report);
+				});
+				return;
+			}
+		}
+		if (metadata.httpHeaders) {
+			if (jsonResult.http_headers !== undefined && jsonResult.http_headers.response !== undefined) {
+				headers.response = jsonResult.http_headers.response;
+			}
+			delete jsonResult.http_headers;
+		}
+		const slangroomResult = JSON.stringify(jsonResult);
+		res.cork(() => {
+			if (metadata.httpHeaders && headers.response !== undefined) {
+				for (const [k, v] of Object.entries(headers.response)) {
+					res.writeHeader(k, v);
+				}
+			}
+			res
+				.writeStatus(metadata.successCode)
+				.writeHeader('Content-Type', metadata.successContentType)
+				.writeHeader('Access-Control-Allow-Origin', '*')
+				.end(slangroomResult);
+			return;
+		});
+	} catch (e) {
+		LOG.fatal(e);
+		res.cork(() =>
+			res
+				.writeStatus(metadata.errorCode)
+				.writeHeader('Access-Control-Allow-Origin', '*')
+				.end((e as Error).message)
+		);
+		return;
+	}
+};
+
+const generatePost = (
+	app: TemplatedApp,
+	endpoint: Endpoints,
+	schema: JSONSchema,
+	LOG: Logger<ILogObj>,
+	action: 'add' | 'update' | 'delete'
+) => {
+	const { path, metadata } = endpoint;
+	app.post(path, (res, req) => {
+		if (action === 'delete') {
+			notFound(res, LOG, new Error(`Not found on ${path}`));
+			return;
+		}
+		if (metadata.disablePost) {
+			methodNotAllowed(res, LOG, new Error(`Post method not allowed on ${path}`));
+			return;
+		}
+		let headers: Record<string, Record<string, string>> = {};
+		headers.request = {};
+		req.forEach((k, v) => {
+			headers.request[k] = v;
+		});
+		/**
+		 * Code may break on `slangroom.execute`
+		 * so it's important to attach the `onAborted` handler before everything else
+		 */
+		res.onAborted(() => {
+			res.writeStatus(metadata.errorCode ? metadata.errorCode : '500').end('Aborted');
+		});
+		let buffer: Buffer;
+		res.onData((d, isLast) => {
+			let chunk = Buffer.from(d);
+			if (isLast) {
+				let data;
+				try {
+					data = JSON.parse(buffer ? Buffer.concat([buffer, chunk]) : chunk);
+				} catch (e) {
+					L.error(e);
+					res
+						.writeStatus(metadata.errorCode)
+						.writeHeader('Access-Control-Allow-Origin', '*')
+						.end((e as Error).message);
+					return;
+				}
+				execZencodeAndReply(res, endpoint, data, headers, schema, LOG);
+				return;
+			} else {
+				if (buffer) {
+					buffer = Buffer.concat([buffer, chunk]);
+				} else {
+					buffer = Buffer.concat([chunk]);
+				}
+			}
+		});
+	});
+};
+
+const generateGet = (
+	app: TemplatedApp,
+	endpoint: Record<string, any>,
+	schema: JSONSchema,
+	LOG: Logger<ILogObj>,
+	action: 'add' | 'update' | 'delete'
+) => {
+	const { path, metadata } = endpoint;
+	app.get(path, async (res, req) => {
+		if (action === 'delete') {
+			notFound(res, LOG, new Error(`Not found on ${path}`));
+			return;
+		}
+		if (metadata.disableGet) {
+			methodNotAllowed(res, LOG, new Error(`Get method not allowed on ${path}`));
+			return;
+		}
+		let headers: Record<string, Record<string, string>> = {};
+		headers.request = {};
+		req.forEach((k, v) => {
+			headers.request[k] = v;
+		});
+		/**
+		 * Code may break on `slangroom.execute`
+		 * so it's important to attach the `onAborted` handler before everything else
+		 */
+		res.onAborted(() => {
+			res.writeStatus(metadata.errorCode).end('Aborted');
+		});
+
+		try {
+			const data: Record<string, unknown> = getQueryParams(req);
+			execZencodeAndReply(res, endpoint, data, headers, schema, LOG);
+		} catch (e) {
+			LOG.fatal(e);
+			res.writeStatus(metadata.errorCode).end((e as Error).message);
+			return;
+		}
+	});
+};
+
+export const generateRoute = async (
+	app: TemplatedApp,
+	endpoint: Endpoints,
+	action: 'add' | 'update' | 'delete'
+) => {
+	const { contract, path, metadata } = endpoint;
+	if (metadata.hidden) return;
+
+	let schema = null;
+	if (action !== 'delete') {
+		schema = await getSchema(endpoint);
+		if (!schema) {
+			L.warn(`🛟  ${path} 🚧 Please provide a valide schema`);
+			schema = { type: 'object', properties: {} };
+		}
+	}
+
+	app.options(path, (res) => {
+		res.onAborted(() => {
+			res
+				.writeStatus('500')
+				.writeHeader('Access-Control-Allow-Origin', '*')
+				.writeHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+				.writeHeader('Access-Control-Allow-Headers', 'content-type')
+				.end('Aborted');
+		});
+		setCorsHeaders(res);
+		res.end();
+	});
+
+	const LOG = L.getSubLogger({
+		stylePrettyLogs: true,
+		prettyLogTemplate:
+			'{{logLevelName}}\t📜 {{zencode}}.zen \t🕙 {{dateIsoStr}} \t📁 {{filePathWithLine}}\t\t',
+		overwrite: {
+			addPlaceholders: (logObjMeta: IMeta, placeholderValues: Record<string, string | number>) => {
+				placeholderValues['zencode'] = path;
+			}
+		}
+	});
+	generateGet(app, endpoint, schema, LOG, action);
+	generatePost(app, endpoint, schema, LOG, action);
+
+	app.get(path + '/raw', (res, req) => {
+		if (action === 'delete') {
+			notFound(res, LOG, new Error(`Not found on ${path}/raw`));
+			return;
+		}
+		res.writeStatus('200 OK').writeHeader('Content-Type', 'text/plain').end(contract);
+	});
+
+	app.get(path + '/app', async (res, req) => {
+		if (action === 'delete') {
+			notFound(res, LOG, new Error(`Not found on ${path}/app`));
+			return;
+		}
+		const result = _.template(proctoroom)({
+			contract: contract,
+			schema: JSON.stringify(schema),
+			title: path || 'Welcome 🥳 to ',
+			description: contract,
+			endpoint: `//${config.hostname}:${config.port}${path}`
+		});
+
+		res.writeStatus('200 OK').writeHeader('Content-Type', 'text/html').end(result);
+	});
+	L.info(`${emoji[action]} ${path}`);
+};

--- a/tests/workflow.stepci.yml
+++ b/tests/workflow.stepci.yml
@@ -91,7 +91,7 @@ tests:
           method: GET
           check:
             status: 404
-            body: Not found
+            body: Not Found
 
   broken:
     steps:
@@ -313,7 +313,7 @@ tests:
           method: GET
           check:
             status: 405
-            body: Method not allowed
+            body: Method Not Allowed
       - name: GET request
         http:
           url: http://${{env.host}}/meta/content_type


### PR DESCRIPTION
- fix: detect also update and delete as changes
- fix: on change reload also public directory
- chore(cli): fix typo in port option documentation
- chore(openapi): remove an async leftover
- refactor: throw an error if the reload fails
- fix: on change do not stop and restart the app, just reloaa the routes
- chore(index): apply prettier
- refactor: create a file to handle responses
- refactor(directory): add one event handler for each event emitted from live-directory
- fix: on creation, update or removal of file that defines an endpoint regenerate the correct endpoint instead of reloading all of them
