### PR TITLE
fix: correctly hanlde and use basepath for static files and health api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,12 +130,11 @@ const ncrApp = async () => {
 			const contract = `
 Rule unknown ignore
 Given I connect to 'hi_endpoint' and do get and output into 'hi_result'
-and debug
 Given I have a 'string' named 'result' in 'hi result'
 Then print the 'result'
 `;
 			const keys = {
-				hi_endpoint: `http://localhost:${config.port}/sayhi`
+				hi_endpoint: `http://${config.hostname}:${config.port}${config.basepath}/sayhi`
 			};
 			try {
 				const { result } = await s.execute(contract, { keys });

--- a/src/routeUtils.ts
+++ b/src/routeUtils.ts
@@ -30,8 +30,6 @@ type MethodNames =
   | 'any'
   | 'ws';
 
-// type MethodNames = 'get' | 'post' | 'options' | 'del' | 'patch' | 'put' | 'head' | 'connect' | 'trace' | 'any' | 'ws';
-
 export const createAppWithBasePath = (basepath: string): TemplatedApp => {
 	const app = App();
 


### PR DESCRIPTION
- chore: remove useless comment
- fix: remove basepath when resolving static files
- fix: health endpoint now use also basepath to correctly get sayhi api
